### PR TITLE
Implement Admin Mode (teacher login + protected registration actions)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,15 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
 import os
 from pathlib import Path
+from typing import Optional
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +22,27 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+class TeacherLoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+teachers_file = current_dir / "teachers.json"
+teacher_sessions = {}
+
+
+def load_teacher_credentials():
+    with teachers_file.open("r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def require_teacher_auth(token: Optional[str]):
+    if not token or token not in teacher_sessions:
+        raise HTTPException(status_code=401, detail="Teacher authentication required")
+
+    return teacher_sessions[token]
 
 # In-memory activity database
 activities = {
@@ -88,9 +113,51 @@ def get_activities():
     return activities
 
 
+@app.post("/auth/teacher/login")
+def teacher_login(payload: TeacherLoginRequest):
+    teacher_credentials = load_teacher_credentials()
+    valid_password = teacher_credentials.get(payload.username)
+
+    if not valid_password or valid_password != payload.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    teacher_sessions[token] = payload.username
+
+    return {
+        "message": "Logged in successfully",
+        "token": token,
+        "username": payload.username,
+    }
+
+
+@app.post("/auth/teacher/logout")
+def teacher_logout(x_teacher_token: Optional[str] = Header(default=None, alias="X-Teacher-Token")):
+    require_teacher_auth(x_teacher_token)
+    del teacher_sessions[x_teacher_token]
+    return {"message": "Logged out successfully"}
+
+
+@app.get("/auth/teacher/status")
+def teacher_status(x_teacher_token: Optional[str] = Header(default=None, alias="X-Teacher-Token")):
+    if not x_teacher_token or x_teacher_token not in teacher_sessions:
+        return {"authenticated": False}
+
+    return {
+        "authenticated": True,
+        "username": teacher_sessions[x_teacher_token],
+    }
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: Optional[str] = Header(default=None, alias="X-Teacher-Token"),
+):
     """Sign up a student for an activity"""
+    require_teacher_auth(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +178,14 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_teacher_token: Optional[str] = Header(default=None, alias="X-Teacher-Token"),
+):
     """Unregister a student from an activity"""
+    require_teacher_auth(x_teacher_token)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,80 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userMenuToggle = document.getElementById("user-menu-toggle");
+  const userMenu = document.getElementById("user-menu");
+  const openLoginModalBtn = document.getElementById("open-login-modal");
+  const teacherLogoutBtn = document.getElementById("teacher-logout");
+  const teacherStatus = document.getElementById("teacher-status");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModalBtn = document.getElementById("close-login-modal");
+  const teacherLoginForm = document.getElementById("teacher-login-form");
+  const teacherUsernameInput = document.getElementById("teacher-username");
+  const teacherPasswordInput = document.getElementById("teacher-password");
+  const emailInput = document.getElementById("email");
+  const signupButton = signupForm.querySelector("button[type='submit']");
+
+  let teacherToken = localStorage.getItem("teacherToken");
+  let teacherUsername = localStorage.getItem("teacherUsername");
+
+  function authHeaders() {
+    if (!teacherToken) {
+      return {};
+    }
+
+    return { "X-Teacher-Token": teacherToken };
+  }
+
+  function setAuthUi(isAuthenticated) {
+    if (isAuthenticated) {
+      teacherStatus.textContent = `Teacher mode: logged in as ${teacherUsername}`;
+      teacherStatus.className = "success";
+      openLoginModalBtn.classList.add("hidden");
+      teacherLogoutBtn.classList.remove("hidden");
+      emailInput.disabled = false;
+      activitySelect.disabled = false;
+      signupButton.disabled = false;
+      signupButton.title = "";
+    } else {
+      teacherStatus.textContent = "Teacher mode: logged out";
+      teacherStatus.className = "info";
+      openLoginModalBtn.classList.remove("hidden");
+      teacherLogoutBtn.classList.add("hidden");
+      emailInput.disabled = true;
+      activitySelect.disabled = true;
+      signupButton.disabled = true;
+      signupButton.title = "Only logged-in teachers can register students";
+    }
+  }
+
+  function clearTeacherSession() {
+    teacherToken = null;
+    teacherUsername = null;
+    localStorage.removeItem("teacherToken");
+    localStorage.removeItem("teacherUsername");
+  }
+
+  async function refreshTeacherStatus() {
+    try {
+      const response = await fetch("/auth/teacher/status", {
+        headers: authHeaders(),
+      });
+      const result = await response.json();
+
+      if (result.authenticated) {
+        teacherUsername = result.username;
+        localStorage.setItem("teacherUsername", teacherUsername);
+        setAuthUi(true);
+      } else {
+        clearTeacherSession();
+        setAuthUi(false);
+      }
+    } catch (error) {
+      clearTeacherSession();
+      setAuthUi(false);
+      console.error("Error checking teacher status:", error);
+    }
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -21,7 +95,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft =
           details.max_participants - details.participants.length;
 
-        // Create participants HTML with delete icons instead of bullet points
+        const isTeacherAuthenticated = Boolean(teacherToken);
+
+        // Create participants HTML with delete icons for logged-in teachers
         const participantsHTML =
           details.participants.length > 0
             ? `<div class="participants-section">
@@ -30,7 +106,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherAuthenticated
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +149,13 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!teacherToken) {
+      messageDiv.textContent = "Only logged-in teachers can unregister students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,6 +167,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
@@ -92,6 +180,10 @@ document.addEventListener("DOMContentLoaded", () => {
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
+        if (response.status === 401) {
+          clearTeacherSession();
+          setAuthUi(false);
+        }
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
@@ -114,6 +206,13 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!teacherToken) {
+      messageDiv.textContent = "Only logged-in teachers can register students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +223,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
@@ -137,6 +237,10 @@ document.addEventListener("DOMContentLoaded", () => {
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
+        if (response.status === 401) {
+          clearTeacherSession();
+          setAuthUi(false);
+        }
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
@@ -155,6 +259,86 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  userMenuToggle.addEventListener("click", () => {
+    userMenu.classList.toggle("hidden");
+  });
+
+  openLoginModalBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userMenu.classList.add("hidden");
+  });
+
+  closeLoginModalBtn.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    teacherLoginForm.reset();
+  });
+
+  teacherLoginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    try {
+      const response = await fetch("/auth/teacher/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: teacherUsernameInput.value,
+          password: teacherPasswordInput.value,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        messageDiv.textContent = result.detail || "Login failed";
+        messageDiv.className = "error";
+        messageDiv.classList.remove("hidden");
+        return;
+      }
+
+      teacherToken = result.token;
+      teacherUsername = result.username;
+      localStorage.setItem("teacherToken", teacherToken);
+      localStorage.setItem("teacherUsername", teacherUsername);
+
+      setAuthUi(true);
+      loginModal.classList.add("hidden");
+      teacherLoginForm.reset();
+      fetchActivities();
+
+      messageDiv.textContent = `Logged in as ${teacherUsername}`;
+      messageDiv.className = "success";
+      messageDiv.classList.remove("hidden");
+    } catch (error) {
+      messageDiv.textContent = "Login failed. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  teacherLogoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/teacher/logout", {
+        method: "POST",
+        headers: authHeaders(),
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    clearTeacherSession();
+    setAuthUi(false);
+    userMenu.classList.add("hidden");
+    fetchActivities();
+
+    messageDiv.textContent = "Logged out";
+    messageDiv.className = "success";
+    messageDiv.classList.remove("hidden");
+  });
+
   // Initialize app
+  refreshTeacherStatus();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <header>
+      <div id="teacher-controls">
+        <button id="user-menu-toggle" type="button" aria-label="Open user menu">👤</button>
+        <div id="user-menu" class="hidden">
+          <button id="open-login-modal" type="button">Login</button>
+          <button id="teacher-logout" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +30,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="teacher-status" class="info">Teacher mode: logged out</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +52,26 @@
     <footer>
       <p>&copy; 2023 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="teacher-login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username</label>
+            <input type="text" id="teacher-username" required />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password</label>
+            <input type="password" id="teacher-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="close-login-modal" type="button">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,48 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+#teacher-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  text-align: right;
+}
+
+#user-menu-toggle {
+  background-color: white;
+  color: #1a237e;
+  padding: 8px 10px;
+  border-radius: 999px;
+}
+
+#user-menu {
+  margin-top: 8px;
+  background-color: white;
+  border: 1px solid #d9def4;
+  border-radius: 8px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 120px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+#user-menu.hidden {
+  display: none;
+}
+
+#user-menu button {
+  width: 100%;
 }
 
 header h1 {
@@ -164,6 +200,11 @@ button:hover {
   background-color: #3949ab;
 }
 
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .message {
   margin-top: 20px;
   padding: 10px;
@@ -190,6 +231,35 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 20;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  width: 100%;
+  max-width: 380px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "teacher1": "teachpass123",
+  "teacher2": "securepass456"
+}


### PR DESCRIPTION
## Summary
Implements issue #5 (Admin Mode) by adding teacher authentication and restricting student registration management to logged-in teachers.

## What changed
- Added teacher auth endpoints in backend:
  - `POST /auth/teacher/login`
  - `POST /auth/teacher/logout`
  - `GET /auth/teacher/status`
- Protected registration endpoints so only authenticated teachers can use them:
  - `POST /activities/{activity_name}/signup`
  - `DELETE /activities/{activity_name}/unregister`
- Added `src/teachers.json` with teacher credentials (per issue requirement).
- Added UI controls:
  - user icon menu (login/logout)
  - teacher login modal
  - visible teacher mode status
- Disabled registration form for logged-out users.
- Hidden unregister buttons for logged-out users.

## Files changed
- `src/app.py`
- `src/teachers.json`
- `src/static/index.html`
- `src/static/app.js`
- `src/static/styles.css`

## Notes
- This is a lightweight session implementation using in-memory tokens to match current app simplicity.
- If needed next, we can move tokens/credentials to a persistent store and add password hashing.